### PR TITLE
Support ArchiSteamFarm OS-specific builds

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -125,6 +125,7 @@ dotnet_code_quality_unused_parameters = all:warning
 dotnet_diagnostic.ca1028.severity = silent
 dotnet_diagnostic.ca1031.severity = silent
 dotnet_diagnostic.ca1863.severity = silent
+dotnet_diagnostic.ide0305.severity = silent
 
 # Rule - almost everything
 dotnet_naming_rule.almost_everything_must_be_pascal_case.severity = warning

--- a/ASF.AchievementsBooster/Handler/AppHandler.cs
+++ b/ASF.AchievementsBooster/Handler/AppHandler.cs
@@ -50,13 +50,7 @@ internal sealed class AppHandler {
     Logger = logger;
   }
 
-  internal void UpdateOwnedGames(Dictionary<uint, string>? ownedGamesDictionary) {
-    if (ownedGamesDictionary == null) {
-      return;
-    }
-
-    HashSet<uint> newOwnedGames = [.. ownedGamesDictionary.Keys];
-
+  internal void UpdateOwnedGames(HashSet<uint> newOwnedGames) {
     if (OwnedGames.Count == 0) {
       Logger.Debug(string.Format(CultureInfo.CurrentCulture, Messages.GamesOwned, string.Join(",", newOwnedGames)));
 


### PR DESCRIPTION
ArchiSteamFarm OS-specific builds can't work with the following:

- `Enumerable.Intersect` method
- Creating a `HashSet` from an `Dictionary.Keys` using collection expressions